### PR TITLE
Add installation instructions for older opam

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,23 @@ The original implementation of Multicore OCaml allowed a user to `Obj.clone_cont
 
 ## Running the examples
 
-To run the examples with Multicore OCaml, be sure to install [Opam with these instructions](https://opam.ocaml.org/doc/Install.html).
+To run the examples with Multicore OCaml, be sure to install [Opam with these instructions](https://opam.ocaml.org/doc/Install.html). If your version of Opam (`opam --version`) is greater than or equal to `2.1` then the following instructions will work:
 
 ```bash
 # After cloning this repository, create a 5.0.0 switch
-$ opam update
+opam update
 # Add the alpha repository to get unreleased 5.0.0 compatible libraries
-$ opam switch create 5.0.0+trunk --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
-$ opam install . --deps-only
-$ make
+opam switch create 5.0.0+trunk --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+opam install . --deps-only
 ```
 
-This builds all of the examples. If you want to run a single executable that is build with `dune` you can run:
+If your version of Opam is less than `2.1`, then you will also need to add the beta repository when creating the switch. All of the other commands remain the same.
+
+```
+opam switch create 5.0.0+trunk --repo=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+```
+
+Running `make` will build all of the examples. If you want to run a single executable that is built with `dune` you can run:
 
 ```
 $ dune exec -- ./<executable_name>.exe


### PR DESCRIPTION
For opam versions less than `2.1` users will have to enable the beta-repository.