### PR TITLE
Refactor files [state.ml] and [ref.ml].

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-EXE := concurrent.exe state.exe ref.exe transaction.exe echo.exe \
+EXE := concurrent.exe ref.exe transaction.exe echo.exe \
 	dyn_wind.exe generator.exe promises.exe reify_reflect.exe \
 	MVar_test.exe chameneos.exe eratosthenes.exe pipes.exe loop.exe \
 	fringe.exe algorithmic_differentiation.exe
@@ -7,6 +7,9 @@ all: $(EXE)
 
 concurrent.exe: sched.mli sched.ml concurrent.ml
 	dune build concurrent.exe
+
+ref.exe: state.ml ref.ml
+	dune build ref.exe
 
 echo.exe: aio/aio.mli aio/aio.ml aio/echo.ml
 	dune build aio/echo.exe

--- a/dune
+++ b/dune
@@ -7,12 +7,8 @@
  (modules sched concurrent))
 
 (executables
- (names state)
- (modules state))
-
-(executables
  (names ref)
- (modules ref))
+ (modules state ref))
 
 (executables
  (names transaction)

--- a/ref.ml
+++ b/ref.ml
@@ -1,71 +1,183 @@
-open Printf
+(* ref.ml *)
+
+(* This file introduces the type [HEAP] formalizing a heap
+   as a mechanism for dynamically allocating memory cells.
+
+   Two heap implementations are given:
+   (1) [FCMBasedHeap], where references are implemented as first-class
+       modules declaring effect names [Get] and [Set].
+   (2) [RecordBasedHeap], where references are implemented as pairs of
+       functions [get] and [set].
+*)
+
 open Effect
 open Effect.Deep
+open State
 
-module type STATE = sig
+
+(* --------------------------------------------------------------------------- *)
+(** Type Definitions. *)
+
+(* [REF] is the interface of dynamically allocated references. *)
+module type REF = sig
   type 'a t
-
   val ref  : 'a -> 'a t
   val (!)  : 'a t -> 'a
   val (:=) : 'a t -> 'a -> unit
-
   val run  : (unit -> 'a) -> 'a
 end
 
-module State : STATE = struct
+(* [HEAP] is the type of a functor that, given the implementation of a cell,
+   implements dynamically allocated references. *)
+module type HEAP = CELL -> REF
 
+
+(* --------------------------------------------------------------------------- *)
+(** Heap Implementation Based on First-Class Modules. *)
+
+(* [FCMBasedHeap] implements a heap using first-class modules.
+
+   The idea is to implement the type of references ['a t] as the
+   type of first-class modules declaring the pair of effect names
+   [Get] and [Set].
+
+   The operations [!] and [:=] are then simply implemented as [perform]
+   instructions to one of the effect names passed as arguments.
+
+   The interpretation of these operations is given by the functions
+   [get] and [set] obtained from a new instance of [Cell].
+*)
+
+module FCMBasedHeap : HEAP = functor (Cell : CELL) -> struct
+  (* [EFF] declares a pair of effect names [Get] and [Set]. *)
+  module type EFF = sig
+    type t
+    type _ Effect.t += Get : t Effect.t
+    type _ Effect.t += Set : t -> unit Effect.t
+  end
+  (* ['a t] is the type of first-class [EFF] modules.
+     The effect-name declarations in [EFF] become first-class. *)
+  type 'a t = (module EFF with type t = 'a)
+
+  type _ Effect.t += Ref : 'a -> ('a t) Effect.t
+
+  let ref init = perform (Ref init)
+  let (!) : type a. a t -> a =
+    fun (module E) -> perform E.Get
+  let (:=) : type a. a t -> a -> unit =
+    fun (module E) y -> perform (E.Set y)
+
+  (* [fresh()] allocates fresh effect names [Get] and [Set],
+      and packs these names into a first-class module. *)
+  let fresh (type a) () : a t =
+    (module struct
+      type t = a
+      type _ Effect.t += Get : t Effect.t
+      type _ Effect.t += Set : t -> unit Effect.t
+    end)
+
+  let run main =
+    try_with main () {
+      effc = fun (type b) (e : b Effect.t) ->
+        match e with
+        | Ref init -> Some (fun (k : (b, _) continuation) ->
+            (init, k) |> fun (type a) ((init, k) : a * (a t, _) continuation) ->
+            let module E = (val (fresh() : a t)) in
+            let module C = Cell(struct type t = a end) in
+            let main() =
+              try_with (continue k) (module E) {
+                effc = fun (type c) (e : c Effect.t) ->
+                  match e with
+                  | E.Get -> Some (fun (k : (c, _) continuation) ->
+                      continue k (C.get() : a))
+                  | E.Set y -> Some (fun k ->
+                      continue k (C.set y))
+                  | _ -> None
+              }
+            in
+            snd (C.run ~init main)
+          )
+        | _ -> None
+    }
+end
+
+
+(* --------------------------------------------------------------------------- *)
+(** Heap Implementation Based on Records. *)
+
+(* [RecordBasedHeap] implements a reference as a pair of functions [get]
+   and [set]. The operations [!] and [:=] need simply to choose between
+   one these two functions. The operation [ref] is implemented as an
+   effect [Ref]. When performed, a new instance of [Cell] is created and the
+   continuation is resumed with the pair of functions [get] and [set] given
+   by this new cell.
+*)
+
+module RecordBasedHeap : HEAP = functor (Cell : CELL) -> struct
   type 'a t = {
     get : unit -> 'a;
     set : 'a -> unit;
   }
+  type _ Effect.t += Ref : 'a -> ('a t) Effect.t
 
-  type _ Effect.t += Ref : 'a -> 'a t Effect.t
   let ref init = perform (Ref init)
+  let (!) {get; _} = get()
+  let (:=) {set; _} y = set y
 
-  let (!)  : type a. a t -> a =
-    fun {get; _} -> get ()
-
-  let (:=) : type a. a t -> a -> unit =
-    fun {set; _} y -> set y
-
-  let run f =
-    try_with f () {
-      effc = fun (type a) (e : a Effect.t) ->
-        match e with 
-        | Ref init -> Some (fun (k : (a, _) continuation) ->
-          (* trick to name the existential type introduced by the matching: *)
-          (init, k) |> fun (type b) (init, k : b * (b t, _) continuation) ->
-          let open struct
-            type _ Effect.t += Get : b Effect.t
-            type _ Effect.t += Set : b -> unit Effect.t
-          end in
-          let get () = perform Get in
-          let set y = perform (Set y) in
-          init |>
-          match_with (continue k) {get; set} {
-            retc = (fun result -> fun _x -> result);
-            exnc = raise;
-            effc = fun (type c) (e : c Effect.t) ->
-              match e with
-              | Get -> Some (fun (k : (c, _) continuation) -> fun (x : b) -> continue k x x)
-              | Set y -> Some (fun k -> fun _x -> continue k () y)
-              | _ -> None
-          })
+  let run main =
+    try_with main () {
+      effc = fun (type b) (e : b Effect.t) ->
+        match e with
+        | Ref init -> Some (fun (k : (b, _) continuation) ->
+            (init, k) |> fun (type a) ((init, k) : a * (a t, _) continuation) ->
+            let open Cell(struct type t = a end) in
+            snd (run ~init (fun _ -> continue k {get; set}))
+          )
         | _ -> None
     }
-    end
+end
 
-open State
 
-let foo () =
-  let r1 = ref "Hello" in
-  let r2 = ref 10 in
-  printf "%s\n" (!r1);
-  printf "%d\n" (!r2);
-  r1 := "World";
-  r2 := 20;
-  printf "%s\n" (!r1);
-  printf "%d\n" (!r2);
-  "Done"
+(* --------------------------------------------------------------------------- *)
+(** Examples. *)
 
-let _ = run foo
+open Printf
+
+let _ =
+  printf "Opening module Ref...\n"
+
+let _ =
+  printf "Running tests...\n"
+
+let _ =
+  let heaps : (module REF) list = [
+    (module FCMBasedHeap(StPassing));
+    (module RecordBasedHeap(StPassing));
+    (module FCMBasedHeap(LocalMutVar));
+    (module RecordBasedHeap(LocalMutVar));
+    (module FCMBasedHeap(GlobalMutVar));
+    (module RecordBasedHeap(GlobalMutVar))
+  ] in
+
+  List.iter (fun heap ->
+    let open (val heap : REF) in
+    let main () =
+      let fibs = ref [] in
+      let a, b = ref 0, ref 1 in
+      for _i = 0 to 10 do
+        let fibsv, av, bv = !fibs, !a, !b in
+        fibs := av :: fibsv;
+        a := bv;
+        b := av + bv
+      done;
+      let fibsv, av, bv = !fibs, !a, !b in
+      assert (((List.hd fibsv), av, bv) = (55, 89, 144))
+    in
+    run main
+  ) heaps
+
+let _ =
+  printf "End of tests.\n"
+
+let _ =
+  printf "End of module Ref.\n"

--- a/state.ml
+++ b/state.ml
@@ -1,53 +1,248 @@
-open Printf
-(* From: https://gist.github.com/kayceesrk/3c307d0340fbfc68435d4769ad447e10 *)
+(* state.ml *)
+
+(* This file introduces the type [CELL] formalizing a memory cell
+   as a functor that, for any given type, implements the [STATE]
+   interface.
+
+   Three cell implementations are given:
+   (1) [GlobalMutVar], an implementation using global state.
+   (2) [LocalMutVar], an implementation using local state.
+   (3) [StPassing], a functional implementation in state-passing style.
+
+   The stating-passing--style implementation comes from
+ 
+     https://gist.github.com/kayceesrk/3c307d0340fbfc68435d4769ad447e10 .
+*)
+
 open Effect
 open Effect.Deep
 
+
+(* --------------------------------------------------------------------------- *)
+(** Type Definitions. *)
+
+(* [TYPE] specifies a type [t]. *)
+module type TYPE = sig
+  type t
+end
+
+(* [STATE] is the type of a module that offers the functions [get] and [set]
+   for manipulating a piece of mutable state with contents in the type [t].
+   This module must also offer a function [run] for handling computations
+   that perform the operations [get] and [set].
+*)
 module type STATE = sig
   type t
-  val put : t -> unit
   val get : unit -> t
-  val run : (unit -> 'a) -> init:t -> t * 'a
+  val set : t -> unit
+  val run : init:t -> (unit -> 'a) -> t * 'a
 end
 
-module State (S : sig type t end) : STATE with type t = S.t = struct
+(* [CELL] is the type of a functor that produces an
+   implementation of [STATE] for any given type.
+*)
+module type CELL = functor (T : TYPE) -> STATE with type t = T.t
 
-  type t = S.t
+(* Note.
 
-  type _ Effect.t += Put : t -> unit Effect.t
-  let put v = perform (Put v)
+     The signatures [STATE] and [CELL] are equivalent to the following
+     record types, respectively:
 
-  type _ Effect.t += Get : t Effect.t
-  let get () = perform Get
-
-  let run (type a) (f : unit -> a) ~init : t * a =
-    let comp =
-      match_with f ()
-      { retc = (fun x -> (fun s -> (s, x)));
-        exnc = (fun e -> raise e);
-        effc = fun (type b) (e : b Effect.t) ->
-                 match e with
-                 | Get -> Some (fun (k : (b, t -> (t * a)) continuation) ->
-                     (fun (s : t) -> continue k s s))
-                 | Put s' -> Some (fun k ->
-                     (fun _s -> continue k () s'))
-                 | e -> None
+     ```ocaml
+       type 's state = {
+         get : unit -> 's;
+         set : 's -> unit;
+         run : 'a. init:'s -> (unit -> 'a) -> 's * 'a
        }
-    in comp init
+
+       type cell = {
+         fresh : 's. unit -> 's state
+       }
+     ```
+
+     We prefer the signatures [STATE] and [CELL] over the record types,
+     because implementations of these interfaces often need to declare
+     new effect names (which comes more naturally in the scope of a
+     module definition) and because we need a module signature of cells
+     to declare the functor signature [HEAP] in the file [ref.ml] (if we
+     want to avoid types such as [cell -> (module REF)]).
+*)
+
+
+(* --------------------------------------------------------------------------- *)
+(** Global State. *)
+
+(* [GlobalMutVar] implements a cell using the global state.
+
+   The module produced by this functor allocates a fresh reference [var],
+   which initially holds the value [None]. The operations [get] and [set]
+   perform accesses to this reference, but can be called only in the scope
+   of [run].
+
+   Nested applications of [run] (given by the same module), such as
+
+   ```ocaml
+     let open GlobalMutVar(struct type t = int end) in
+     run ~init:0 (fun _ -> run ~init:1 (fun _ -> ()))
+   ```,
+
+   are unsafe, because the innermost [run] resets [var] to [None].
+   The final read to [var] performed by the outermost [run] (to construct
+   the pair [t * 'a]) is thus invalidated.
+
+   Parallel applications of [run] (given by the same module) are unsafe,
+   because an instance of [run] can reset [var] to [None] while parallel
+   instances are still ongoing. Moreover, accesses to [var] will suffer
+   from race conditions.
+*)
+module GlobalMutVar : CELL = functor (T : TYPE) -> struct
+  type t = T.t
+
+  let var = ref None
+
+  let get() = match !var with Some x -> x | None -> assert false
+  let set y = var := Some y
+
+  let run ~init main =
+    set init      |> fun _   ->
+    main()        |> fun res ->
+    get()         |> fun x   ->
+    (var := None) |> fun _   ->
+    (x, res)
 end
 
-module IS = State (struct type t = int end)
-module SS = State (struct type t = string end)
 
-let foo () : unit =
-  printf "%d\n" (IS.get ());
-  IS.put 42;
-  printf "%d\n" (IS.get ());
-  IS.put 21;
-  printf "%d\n" (IS.get ());
-  SS.put "hello";
-  printf "%s\n" (SS.get ());
-  SS.put "world";
-  printf "%s\n" (SS.get ())
+(* --------------------------------------------------------------------------- *)
+(** Local State. *)
 
-let _ = IS.run (fun () -> SS.run foo ~init:"") ~init:0
+(* [LocalMutVar] implements a cell using effect handlers and local mutable
+   state. The operations [get] and [set] are opaque: they are simply defined
+   as [perform] instructions to the effects [Get] and [Set], respectively.
+   The program [run] interprets these effects as accesses to a local
+   reference [var].
+
+   Nested applications of [run] are safe, but [get] and [set] are handled
+   by the innermost [run]. As an example, the program
+
+   ```ocaml
+     let open LocalMutVar(struct type t = int end) in
+     run ~init:0 (fun _ -> set 3; run ~init:1 (fun _ -> get() + get()))
+   ```
+
+   evaluates to [(3, (1, 2))].
+
+   Parallel executions of [run] in separate stacks are safe. Even though
+   the effect names [Get] and [Set] are shared among multiple instances
+   of [get] and [set], there is no interference among these instances,
+   because effect names are immutable.
+*)
+module LocalMutVar : CELL = functor (T : TYPE) -> struct
+  type t = T.t
+  type _ Effect.t += Get : t Effect.t
+  type _ Effect.t += Set : t -> unit Effect.t
+
+  let get() = perform Get
+  let set y = perform (Set y)
+
+  let run (type a) ~init main : t * a=
+    let var = ref init in
+    match_with main () {
+      retc = (fun res -> (!var, res));
+      exnc = raise;
+      effc = fun (type b) (e : b Effect.t) ->
+        match e with
+        | Get -> Some (fun (k : (b, t * a) continuation) ->
+            continue k (!var : t))
+        | Set y -> Some (fun k ->
+            var := y;
+            continue k ())
+        | _ -> None
+    }
+end
+
+
+(* --------------------------------------------------------------------------- *)
+(** State-Passing Style. *)
+
+(* [StPassing] implements a cell using effect handlers and the state-passing
+   technique.
+
+   Like the functor [LocalMutVar], the operations [get] and [set] are
+   implemented as [perform] instructions to the effects [Get] and [Set],
+   respectively. However, instead of interpreting these effects as accesses to
+   a reference, [run] applies the programming technique state-passing style,
+   which avoids mutable state, thus assigning a functional interpretation to
+   [Get] and [Set]. More specifically, the program [run main ~init] performs
+   the application of the handler that monitors [main()] to the contents of the
+   cell, which initially is [init]. When [main()] performs an effect, the
+   effect branch can access the current state of the cell by immediately
+   returning a lambda abstraction that binds the contents of the cell as its
+   single formal argument. The continuation captures the evaluation context up
+   to (and including) the handler, therefore, when resuming the continuation,
+   the handler must reconstruct its immediately surrounding frame
+   corresponding to the application to the contents of the cell.
+
+   Nested applications of [run] are safe. Parallel executions of [run] in
+   separate stacks are safe. The same remarks as for the functor [LocalMutVar]
+   apply.
+*)
+module StPassing : CELL = functor (T : TYPE) -> struct
+  type t = T.t
+  type _ Effect.t += Get : t Effect.t
+  type _ Effect.t += Set : t -> unit Effect.t
+
+  let get() = perform Get
+  let set y = perform (Set y)
+
+  let run (type a) ~init (main : unit -> a) : t * a =
+    match_with main () {
+      retc = (fun res x -> (x, res));
+      exnc = raise;
+      effc = fun (type b) (e : b Effect.t) ->
+        match e with
+        | Get -> Some (fun (k : (b, t -> (t * a)) continuation) ->
+            fun (x : t) -> continue k x x)
+        | Set y -> Some (fun k ->
+            fun (_x : t) -> continue k () y)
+        | _ -> None
+    } init
+end
+
+
+(* --------------------------------------------------------------------------- *)
+(** Examples. *)
+
+open Printf
+
+let _ =
+  printf "Opening module State...\n"
+
+module IntCell = StPassing(struct type t = int end)
+module StrCell = StPassing(struct type t = string end)
+
+let main() : unit =
+  IntCell.(
+    printf "%d\n" (get());
+    set 42;
+    printf "%d\n" (get());
+    set 21;
+    printf "%d\n" (get())
+  );
+  StrCell.(
+    set "Hello...";
+    printf "%s\n" (get());
+    set "...World!";
+    printf "%s\n" (get ())
+  )
+
+let _ =
+  printf "Running tests...\n";
+  ignore (
+    IntCell.run ~init:0 (fun () ->
+      StrCell.run ~init:"" main
+    )
+  );
+  printf "End of tests.\n"
+
+let _ =
+  printf "End of module State.\n"


### PR DESCRIPTION
The main changes are

1. The decoupling of the implementation of references from the
   implementation of state, thus simplifying the file [ref.ml]

2. The reintroduction of the implementation of references using
   first-class modules (a suggestion from Daniel Hillerström)

The decoupling of references from state is inspired from
Ningning Xie, Youyou Cong and Daan Leijen's paper "First-class
Named Handlers" (HOPE'21).